### PR TITLE
Fix iteritems isn't a method name in Py3

### DIFF
--- a/pundler/config.py
+++ b/pundler/config.py
@@ -28,7 +28,7 @@ class Config(object):
 
         return [
             Package(name, config)
-            for name, config in self.data[self.environment].iteritems()
+            for name, config in self.data[self.environment].items()
         ]
 
     def _check_file(self, filepath):


### PR DESCRIPTION
python version: 3.4.3

```
Traceback (most recent call last):
pundler/config.py", line 31, in packages
    for name, config in self.data[self.environment].iteritems()

AttributeError: 'dict' object has no attribute 'iteritems'
```

Python3にだけ合わせてしまうべきか迷うところですが。
